### PR TITLE
[Fixes] PR1 small fixes

### DIFF
--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,11 +10,15 @@ import os
 
 
 class MoleculeVisualizer:
-    def __init__(self, ag, show_atom_indices=False):
+    def __init__(self, ag, show_atom_indices=False, width, height):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)
         AllChem.Compute2DCoords(self.mol_noh)
         self.molecule_list = ["Molecule"]
+
+        # Add height and width
+        self.width = width
+        self.height = height
         
         # Create the dropdown and other widgets
         self.dropdown = Dropdown(
@@ -65,7 +69,7 @@ class MoleculeVisualizer:
         for checkbox in self.pharmacophore_checkboxes.values():
             checkbox.observe(self.update_display, names="value")
 
-    def display_molecule(self, mol, show_atom_indices):
+    def display_molecule(self, mol, show_atom_indices, width, height):
         highlights = {"atoms": [], "bonds": []}
         highlight_colors = {}
 
@@ -79,7 +83,7 @@ class MoleculeVisualizer:
                 for atom_id in atom_ids:
                     highlight_colors[atom_id] = color
 
-        d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        d = rdMolDraw2D.MolDraw2DSVG(width, height)
         d.drawOptions().addAtomIndices = show_atom_indices
         d.drawOptions().addStereoAnnotation = True
         rdMolDraw2D.PrepareAndDrawMolecule(

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,7 +10,7 @@ import os
 
 
 class MoleculeVisualizer:
-   """A class for small molecule 2D visualization in jupyter notebook
+    """A class for small molecule 2D visualization in jupyter notebook
 
     Parameters:
     -----------
@@ -44,9 +44,9 @@ class MoleculeVisualizer:
     display_rotatable_bonds(mol):
         Display the number of rotatable bonds present in the molecule.
     save_selected_molecule(_):
-        Save the currently displayed molecule as an image.
-    """
-    def __init__(self, ag, show_atom_indices=False, width, height):
+        Save the currently displayed molecule as an image. """
+   
+    def __init__(self, ag, show_atom_indices=False, width=300, height=300):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)
         AllChem.Compute2DCoords(self.mol_noh)

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -79,14 +79,8 @@ class MoleculeVisualizer:
                 for atom_id in atom_ids:
                     highlight_colors[atom_id] = color
 
-        if show_atom_indices:
-            for atom in mol.GetAtoms():
-                atom.SetProp("atomNote", str(atom.GetIdx()))
-        else:
-            for atom in mol.GetAtoms():
-                atom.ClearProp("atomNote")
-
         d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        d.drawOptions().addAtomIndices = show_atom_indices
         d.drawOptions().addStereoAnnotation = True
         rdMolDraw2D.PrepareAndDrawMolecule(
             d, mol, highlightAtoms=highlights["atoms"], highlightBonds=highlights["bonds"],

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -146,7 +146,7 @@ class MoleculeVisualizer:
         smiles = Chem.MolToSmiles(self.mol_noh)
         
         children = [
-            self.display_molecule(self.mol_noh, self.show_atom_indices_checkbox.value),
+            self.display_molecule(self.mol_noh, self.show_atom_indices_checkbox.value, self.width, self.height),
             HTML(f"<h3 style='margin: 0;'>SMILES: {smiles}</h3>")
         ]
         

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,6 +10,42 @@ import os
 
 
 class MoleculeVisualizer:
+   """A class for small molecule 2D visualization in jupyter notebook
+
+    Parameters:
+    -----------
+    ag : MDAnalysis.core.groups.AtomGroup
+        An AtomGroup object representing the molecules that need to be visualized.
+    show_atom_indices : bool, optional
+        Whether to display atom indices of the molecule. Default is False.
+    width : int, optional
+        The width of the image in pixels. Default is 300.
+    height : int, optional
+        The height of the image in pixels. Default is 300.
+
+    Methods:
+    --------
+    display_molecule(mol, show_atom_indices, width, height):
+        Display the molecule with specified options.
+    get_color_for_pharmacophore(family):
+        Get the color codes for highlighting a specific pharmacophore feature.
+    update_display():
+        Update the molecule display based on widget values.
+    display_molecular_weight(mol):
+        Display the molecular weight of the selected molecule.
+    display_logp(mol):
+        Display the LogP value of the selected molecule.
+    display_num_h_donors(mol):
+        Display the number of Hydrogen bond donors of the molecule.
+    display_num_h_acceptors(mol):
+        Display the number of Hydrogen bond acceptors of the molecule.
+    display_tpsa(mol):
+        Display the topological polar surface area (TPSA) of the molecule.
+    display_rotatable_bonds(mol):
+        Display the number of rotatable bonds present in the molecule.
+    save_selected_molecule(_):
+        Save the currently displayed molecule as an image.
+    """
     def __init__(self, ag, show_atom_indices=False, width, height):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)


### PR DESCRIPTION
Fixes the following issues from #1  that are mentioned in #4:

- Addition of example docstring for class `MoleculeVisualizer`
- Added Option to select height and width of Figure
- Changed `ag` and `ag_noh` to `mol` and `mol_noh` in the case that it was a `mol` object
- Change of `show_atom_indices` to use instead `d.drawOptions().addAtomIndices = True`

The issue:

- Removal of `_=None` in`update_display(self, _=None)` was not resolved, due to it being required for the `observe` method that tracks the changes