### PR TITLE
Adjustment of update_display function and f string addition

### DIFF
--- a/mdonatello/__init__.py
+++ b/mdonatello/__init__.py
@@ -5,5 +5,6 @@ MDonatello
 
 # Add imports here
 from importlib.metadata import version
+from .mdonatello import MoleculeVisualizer
 
 __version__ = version("mdonatello")

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,11 +10,15 @@ import os
 
 
 class MoleculeVisualizer:
-    def __init__(self, ag, show_atom_indices=False):
+    def __init__(self, ag, show_atom_indices=False, width, height):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)
         AllChem.Compute2DCoords(self.mol_noh)
         self.molecule_list = ["Molecule"]
+
+        # Add height and width
+        self.width = width
+        self.height = height
         
         # Create the dropdown and other widgets
         self.dropdown = Dropdown(
@@ -65,7 +69,7 @@ class MoleculeVisualizer:
         for checkbox in self.pharmacophore_checkboxes.values():
             checkbox.observe(self.update_display, names="value")
 
-    def display_molecule(self, mol, show_atom_indices):
+    def display_molecule(self, mol, show_atom_indices, width, height):
         highlights = {"atoms": [], "bonds": []}
         highlight_colors = {}
 
@@ -79,7 +83,7 @@ class MoleculeVisualizer:
                 for atom_id in atom_ids:
                     highlight_colors[atom_id] = color
 
-        d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        d = rdMolDraw2D.MolDraw2DSVG(width, height)
         d.drawOptions().addAtomIndices = show_atom_indices
         d.drawOptions().addStereoAnnotation = True
         rdMolDraw2D.PrepareAndDrawMolecule(

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -24,7 +24,7 @@ class MoleculeVisualizer:
         )
         self.show_atom_indices_checkbox = Checkbox(value=show_atom_indices, description="Show atom indices")
         self.physiochem_props_checkbox = Checkbox(value=False, description="Show Physiochemical Properties")
-        self.hbond_props_checkbox = Checkbox(value=False, description=self.get_hbond_description())
+        self.hbond_props_checkbox = Checkbox(value=False, description="Show H-Bond Donors/Acceptors")
         self.save_button = Button(description="Save as PNG")
 
         # Pharmacophore feature detection

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,7 +10,7 @@ import os
 
 
 class MoleculeVisualizer:
-   """A class for small molecule 2D visualization in jupyter notebook
+    """A class for small molecule 2D visualization in jupyter notebook
 
     Parameters:
     -----------
@@ -44,9 +44,9 @@ class MoleculeVisualizer:
     display_rotatable_bonds(mol):
         Display the number of rotatable bonds present in the molecule.
     save_selected_molecule(_):
-        Save the currently displayed molecule as an image.
-    """
-    def __init__(self, ag, show_atom_indices=False, width, height):
+        Save the currently displayed molecule as an image. """
+   
+    def __init__(self, ag, show_atom_indices=False, width=300, height=300):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)
         AllChem.Compute2DCoords(self.mol_noh)

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -47,7 +47,7 @@ class MoleculeVisualizer:
         self.output_dropdown.children = [
             self.dropdown, self.show_atom_indices_checkbox,
             self.physiochem_props_checkbox, self.hbond_props_checkbox
-        ]
+        ] + list(self.pharmacophore_checkboxes.values())
         self.output_molecule = VBox()
         self.output = VBox()
         self.output.children = [self.output_molecule, self.save_button]

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -79,14 +79,8 @@ class MoleculeVisualizer:
                 for atom_id in atom_ids:
                     highlight_colors[atom_id] = color
 
-        if show_atom_indices:
-            for atom in mol.GetAtoms():
-                atom.SetProp("atomNote", str(atom.GetIdx()))
-        else:
-            for atom in mol.GetAtoms():
-                atom.ClearProp("atomNote")
-
         d = rdMolDraw2D.MolDraw2DSVG(300, 300)
+        d.drawOptions().addAtomIndices = show_atom_indices
         d.drawOptions().addStereoAnnotation = True
         rdMolDraw2D.PrepareAndDrawMolecule(
             d, mol, highlightAtoms=highlights["atoms"], highlightBonds=highlights["bonds"],

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -168,27 +168,27 @@ class MoleculeVisualizer:
         
     def display_molecular_weight(self):
         mw = Descriptors.MolWt(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>Molecular Weight: {:.2f} g/mol</p>".format(mw))
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Molecular Weight: {mw:.2f} g/mol</p>")
         
     def display_logp(self):
         logp = Descriptors.MolLogP(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>LogP: {:.2f}</p>".format(logp))
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>LogP: {logp:.2f}</p>")
 
     def display_num_h_donors(self):
         num_h_donors = Descriptors.NumHDonors(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {:.0f}</p>".format(num_h_donors))
+        return HTMLf"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {num_h_donors}</p>")
 
     def display_num_h_acceptors(self):
         num_h_acceptors = Descriptors.NumHAcceptors(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Acceptors: {:.0f}</p>".format(num_h_acceptors))
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Acceptors: {num_h_acceptors}</p>")
     
     def display_tpsa(self):
         tpsa = Descriptors.TPSA(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>Topological Polar Surface Area (TPSA): {:.2f} Å²</p>".format(tpsa))
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Topological Polar Surface Area (TPSA): {tpsa:.2f} Å²</p>")
         
     def display_rotatable_bonds(self):
         rotatable_bonds = Descriptors.NumRotatableBonds(self.mol)
-        return HTML("<p style='margin: 0; margin-left: 100px;'>Number of Rotatable Bonds: {:.0f}</p>".format(rotatable_bonds))
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Number of Rotatable Bonds: {rotatable_bonds}</p>")
         
     def save_selected_molecule(self, _):
         filename = "molecule.png"

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -152,16 +152,16 @@ class MoleculeVisualizer:
         
         if self.physiochem_props_checkbox.value:
             children.extend([
-                self.display_molecular_weight(self.mol_noh),
-                self.display_logp(self.mol_noh),
-                self.display_tpsa(self.mol_noh),
-                self.display_rotatable_bonds(self.mol_noh)
+                self.display_molecular_weight(),
+                self.display_logp(),
+                self.display_tpsa(),
+                self.display_rotatable_bonds()
             ])
             
         if self.hbond_props_checkbox.value:
             children.extend([
-                self.display_num_h_donors(self.mol_noh),
-                self.display_num_h_acceptors(self.mol_noh)
+                self.display_num_h_donors(),
+                self.display_num_h_acceptors()
             ])
         
         self.output_molecule.children = children

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -176,7 +176,7 @@ class MoleculeVisualizer:
 
     def display_num_h_donors(self):
         num_h_donors = Descriptors.NumHDonors(self.mol)
-        return HTMLf"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {num_h_donors}</p>")
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {num_h_donors}</p>")
 
     def display_num_h_acceptors(self):
         num_h_acceptors = Descriptors.NumHAcceptors(self.mol)

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -112,7 +112,7 @@ class MoleculeVisualizer:
         smiles = Chem.MolToSmiles(self.ag_noh)
         
         children = [
-            self.display_molecule(self.ag_noh, self.show_atom_indices_checkbox.value, self.highlight_aromatic_checkbox.value),
+            self.display_molecule(self.ag_noh, self.show_atom_indices_checkbox.value),
             HTML(f"<h3 style='margin: 0;'>SMILES: {smiles}</h3>")
         ]
         

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -146,7 +146,7 @@ class MoleculeVisualizer:
         smiles = Chem.MolToSmiles(self.mol_noh)
         
         children = [
-            self.display_molecule(self.mol_noh, self.show_atom_indices_checkbox.value),
+            self.display_molecule(self.mol_noh, self.show_atom_indices_checkbox.value, self.width, self.height),
             HTML(f"<h3 style='margin: 0;'>SMILES: {smiles}</h3>")
         ]
         

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -10,6 +10,42 @@ import os
 
 
 class MoleculeVisualizer:
+   """A class for small molecule 2D visualization in jupyter notebook
+
+    Parameters:
+    -----------
+    ag : MDAnalysis.core.groups.AtomGroup
+        An AtomGroup object representing the molecules that need to be visualized.
+    show_atom_indices : bool, optional
+        Whether to display atom indices of the molecule. Default is False.
+    width : int, optional
+        The width of the image in pixels. Default is 300.
+    height : int, optional
+        The height of the image in pixels. Default is 300.
+
+    Methods:
+    --------
+    display_molecule(mol, show_atom_indices, width, height):
+        Display the molecule with specified options.
+    get_color_for_pharmacophore(family):
+        Get the color codes for highlighting a specific pharmacophore feature.
+    update_display():
+        Update the molecule display based on widget values.
+    display_molecular_weight(mol):
+        Display the molecular weight of the selected molecule.
+    display_logp(mol):
+        Display the LogP value of the selected molecule.
+    display_num_h_donors(mol):
+        Display the number of Hydrogen bond donors of the molecule.
+    display_num_h_acceptors(mol):
+        Display the number of Hydrogen bond acceptors of the molecule.
+    display_tpsa(mol):
+        Display the topological polar surface area (TPSA) of the molecule.
+    display_rotatable_bonds(mol):
+        Display the number of rotatable bonds present in the molecule.
+    save_selected_molecule(_):
+        Save the currently displayed molecule as an image.
+    """
     def __init__(self, ag, show_atom_indices=False, width, height):
         self.mol = ag.convert_to("RDKit")
         self.mol_noh = Chem.RemoveHs(self.mol)

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -166,28 +166,28 @@ class MoleculeVisualizer:
         
         self.output_molecule.children = children
         
-    def display_molecular_weight(self, mol):
-        mw = Descriptors.MolWt(mol)
+    def display_molecular_weight(self):
+        mw = Descriptors.MolWt(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>Molecular Weight: {:.2f} g/mol</p>".format(mw))
         
-    def display_logp(self, mol):
-        logp = Descriptors.MolLogP(mol)
+    def display_logp(self):
+        logp = Descriptors.MolLogP(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>LogP: {:.2f}</p>".format(logp))
 
-    def display_num_h_donors(self, mol):
-        num_h_donors = Descriptors.NumHDonors(mol)
+    def display_num_h_donors(self):
+        num_h_donors = Descriptors.NumHDonors(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {:.0f}</p>".format(num_h_donors))
 
-    def display_num_h_acceptors(self, mol):
-        num_h_acceptors = Descriptors.NumHAcceptors(mol)
+    def display_num_h_acceptors(self):
+        num_h_acceptors = Descriptors.NumHAcceptors(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Acceptors: {:.0f}</p>".format(num_h_acceptors))
     
-    def display_tpsa(self, mol):
-        tpsa = Descriptors.TPSA(mol)
+    def display_tpsa(self):
+        tpsa = Descriptors.TPSA(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>Topological Polar Surface Area (TPSA): {:.2f} Å²</p>".format(tpsa))
         
-    def display_rotatable_bonds(self, mol):
-        rotatable_bonds = Descriptors.NumRotatableBonds(mol)
+    def display_rotatable_bonds(self):
+        rotatable_bonds = Descriptors.NumRotatableBonds(self.mol)
         return HTML("<p style='margin: 0; margin-left: 100px;'>Number of Rotatable Bonds: {:.0f}</p>".format(rotatable_bonds))
         
     def save_selected_molecule(self, _):


### PR DESCRIPTION
Changes made in regards to #5:

- Adjusted to access in `update_display` function directly `self.mol_noh` instead of passing it as an parameter
- Adjusted `display_molecular_weight`, `display_logp`, `display_num_h_donors`, `display_num_h_acceptors`, `display_tpsa`, `display_rotatable_bonds` to use as input only `self` without the requirement of an additional input of `mol`
- Adjusted the return of HTML to f string format