### PR TITLE
Addition of a logging call to save_selected_molecule

### DIFF
--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -194,4 +194,4 @@ class MoleculeVisualizer:
         filename = "molecule.png"
         img = Draw.MolToImage(self.mol_noh)
         img.save(filename)
-        print(f"Molecule saved as '{filename}'")
+        logging.info(f"Molecule saved as '{filename}'")


### PR DESCRIPTION
Changes made to fix #6:

- Added logging call instead of print for the function `save_selected_molecule`