### PR TITLE
Splitting the display_molecule into display and draw functions

### DIFF
--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -105,7 +105,14 @@ class MoleculeVisualizer:
         for checkbox in self.pharmacophore_checkboxes.values():
             checkbox.observe(self.update_display, names="value")
 
-    def display_molecule(self, mol, show_atom_indices, width, height):
+    def display_molecule(self,):
+        return self.draw_molecule(
+            self.mol_noh,
+            show_atom_indices=self.show_atom_indices_checkbox.value,
+            highlight_aromatic=self.highlight_aromatic_checkbox.value,
+        )
+    
+    def draw_molecule(self, mol, show_atom_indices, width, height):
         highlights = {"atoms": [], "bonds": []}
         highlight_colors = {}
 
@@ -146,7 +153,7 @@ class MoleculeVisualizer:
         smiles = Chem.MolToSmiles(self.mol_noh)
         
         children = [
-            self.display_molecule(self.mol_noh, self.show_atom_indices_checkbox.value, self.width, self.height),
+            self.draw_molecule(self.mol_noh, self.show_atom_indices_checkbox.value, self.width, self.height),
             HTML(f"<h3 style='margin: 0;'>SMILES: {smiles}</h3>")
         ]
         

--- a/mdonatello/mdonatello.py
+++ b/mdonatello/mdonatello.py
@@ -183,7 +183,7 @@ class MoleculeVisualizer:
 
     def display_num_h_donors(self):
         num_h_donors = Descriptors.NumHDonors(self.mol)
-        return HTMLf"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {num_h_donors}</p>")
+        return HTML(f"<p style='margin: 0; margin-left: 100px;'>Number of H-Bond Donors: {num_h_donors}</p>")
 
     def display_num_h_acceptors(self):
         num_h_acceptors = Descriptors.NumHAcceptors(self.mol)


### PR DESCRIPTION
Changes made in Addition to PR #11 to adress comment in #1:

- The function `display_molecule` was divided into two functions `display_molecule` and `draw_molecule` to ease further code maintenance and testing 