### PR TITLE
Fix grammar in getting started documentation

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -27,7 +27,8 @@ Then go into the ``MDonatello`` folder:
 
     cd MDonatello
 
-Finally install of the necessary packages with the following command:
+Finally, install the necessary packages with the following command:
+
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR fixes a small grammar issue in the getting_started.rst documentation to improve clarity for new users.
